### PR TITLE
fix bug and simplify slantstack op, and update documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JetPackTransforms"
 uuid = "e0630bc5-6e1f-509c-a3e4-0aea24bd2b1c"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/docs/src/slantstack.md
+++ b/docs/src/slantstack.md
@@ -1,76 +1,46 @@
 # JopSlantStack
 
-The slant stack is implemented in one of two modes (time or depth).  In depth mode, the implemenation is the wave-number domain with a change of variables from the vertical wave-number ``k_z`` and the horizontal offset wave-number ``k_h`` to the ray parameter ``p_h``.  In the time mode, the implementation is in the frequency/wave-number domain with a change of variables from frequency ``\omega`` and ``k_h`` to ``p_h``.  The change of variables is defined via a mapping from ``k_z`` and ``p`` to ``k_h`` that is derived from dispersion relations for the downward propagating wave 
+The slant stack is implemented in one of two modes (time or depth).  In depth mode, the implementation is the wave-number domain with a change of variables from the vertical wavenumber ``k_z`` and the horizontal subsurface half-offset wavenumber ``k_h`` to the angle of incidence (half of opening angle) ``\theta`` measured with respect to the normal to a planar reflector. An application of this mode would be the conversion of subsurface offset gathers (SSOG) into angle gathers (SSAG). In time mode, the implementation is in the frequency/wavenumber domain with a change of variables from frequency ``\omega`` and surface offset wavenumber ``k_h`` to the ray parameter ``p``. An application of this mode would be the tau-p transform of shot gathers. The change of variables is defined via a mapping from ``k_z`` and ``\theta`` (or ``p``) to ``k_h``. 
+
+We start by noting the definition of the ray parameter ``p`` with takeoff angle ``\gamma`` (with respect to the vertical)
 
 ```math
-\frac{\omega^2}{c^2} = k_{gx}^2 + k_{gz}^2
+p = \frac{\sin\gamma}{c}.
 ```
 
-and the reflected wave
+Note that the ray parameter is preserved in the system for each wave. The relation between the takoff angle and the plane wave can be derived from the dispersion relation and is given by
 
 ```math
-\frac{\omega^2}{c^2} = k_{sx}^2 + k_{sz}^2.
+\sin(\gamma) = \frac{k_x}{\omega/c},
 ```
 
-Next we note the definition of the ray parameter ``p`` with incidence angle ``\theta_s`` and reflected angle ``\theta_g``, and assume that ``\theta=\theta_s=\theta_g``:
+so that the mapping between ``k_h=k_x`` and ``p`` is
 
 ```math
-p = \frac{1}{c}(\sin\theta_g + \sin\theta_s) = \frac{2}{c}(\sin\theta)
+p = \frac{k_x}{\omega}.
 ```
 
-The relation between the incidence angle and the plane wave is given by:
-
+In time mode, this provides the mapping between ``k_h`` and ``p`` via the relation
 ```math
-\sin(\theta) = \frac{k_x}{\omega/c}
+d(\omega,p) = \delta(k_h - p\omega)d(\omega,k_h).
 ```
 
-So that the mapping between `k_h=2k_x` and `p` is,
+In depth mode, we start from the extended imaging condition between source and receiver plane waves
 
 ```math
-p = 2\frac{k_x}{\omega}
+I(x,z,h) = e^{i(k_{sx}(x+h)+k_{sz}z)} e^{-i(k_{rx}(x-h)+k_{rz}z)}=e^{i((k_{sx}-k_{rx})x + (k_{sz}-k_{rz})z + (k_{sx}+k_{rx})h)}.
 ```
 
-In time mode, this provides the mapping between ``k_h`` and ``p`` via the relation:
-```math
-d(\omega,p) = \delta(k_h - p\omega)d(\omega,k_h)
-```s
-
-The offset wave-number is ``k_h=k_{sx}+k_{gx}`` and we make the assumption that ``k_{sx}=k_{gx}`` so that ``k_{sx}=k_{gx}=k_x``, ``k_h=2k_x`` and ``k_{gz}=k_{sz}=k_z``.  Now, we can find the mapping from ``p_h`` and ``k_z`` to ``k_h`` starting from the above dispersion relation we find:
+The image vertical wavenumber and subsurface half-offset wavenumber at a reflection point are given by ``(k_z,k_h) = (k_{sz}-k_{rz}, k_{sx}+k_{rx})``. Assuming a horizontal reflector, we have ``k_{sx} = k_{rx}``, ``k_{sz} = -k_{rz}``, and ``\gamma_s = 2\pi - \gamma_r = \theta - \pi``. Given that ``\frac{k_{sx}}{k_{sz}} = -\tan(\gamma_s)`` we deduce
 
 ```math
-\begin{aligned}
-k_h^2 &= \frac{\omega^2}{c^2} - k_z^2 \\
-k_h   &= \sqrt{\frac{\omega^2}{c^2} - k_z^2} \tag{1}
-\end{aligned}
+k_h = 2k_{sx} = -2k_{sz}\tan(\gamma_s) = -k_z \tan(\theta).
 ```
 
-dividing both sides by ``\omega/c``,
+With some trigonometric manipulations, it can be shown that this relation still holds for non-horizontal reflections.
+
+Thus, the mapping between ``k_h`` and ``\theta`` is given by
 
 ```math
-\frac{ck_h}{\omega} = \sqrt{1 - \left(\frac{ck_z}{\omega}\right)^2}
+d(k_z,\theta) = \delta(k_h + k_z \tan(\theta))d(k_z,k_h).
 ```
-
-note that ``p=k_h/\omega`` so that,
-
-```math
-\begin{aligned}
-cp                              &= \sqrt{1 - \left(\frac{ck_z}{\omega}\right)^2} \\
-(cp)^2                          &= 1 - \left(\frac{ck_z}{\omega}\right)^2 \\
-\left(\frac{c}{\omega}\right)^2 &= \frac{1}{k_z^2}\left(1 - (cp)^2\right) \tag{2}
-\end{aligned}
-```
-
-Substituting equation 2 into equation 1 gives,
-
-```math
-\begin{aligned}
-k_h^2 &= k_z^2\left(1 - (cp)^2\right)^{-1} - k_z^2 \\
-k_h   &= k_z\left[\left(1 - (cp)^2\right)^{-1/2} - 1\right] \tag{3}
-\end{aligned}
-```
-
-In depth mode, we use equation 3 to map between ``k_h`` and ``p`` via the relation:
-```math
-d(k_z,p) = \delta(k_h - (k_z\left[\left(1 - (cp)^2\right)^{-1/2} - 1\right]))d(k_z,k_h)
-```
-

--- a/src/jop_slantstack.jl
+++ b/src/jop_slantstack.jl
@@ -1,32 +1,33 @@
 """
-    A = JopSlantStack(dom[; dz=10.0, dh=10.0, h0=-1000.0, ...])
+    A = JopSlantStack(dom[; dz=1.0, dh=1.0, h0=0.0, ...])
 
-where `A` is the 2D slant-stack operator mapping for `z-h` to `tau-θ` (depth mode) or `t-h` to `tau-p` (time mode).
+where `A` is the 2D slant-stack operator mapping for `z-h` to `z-θ` (depth mode) or `t-h` to `tau-p` (time mode).
 The domain of the operator is `nz` x `nh` with precision T, `dz` is the depth spacing (or time interval),
-`dh` is the half-offset spacing, and `h0` is the origin of the half-offset axis.  The additional named optional arguments
+`dh` is the offset spacing, and `h0` is the origin of the offset axis.  The additional named optional arguments
 along with their default values are,
 
 * `mode="depth` - choose between "depth" and "time" to specify if the input domain is `z-h` or `t-h`.
-* `theta=-60:1.0:60` - range of opening angles used when `mode="depth"`.  The ray parameter is: p=sin(theta/2)/c
-* `p=range(-dt/dx,dt/dx,128)` - ray parameter sampling used when `mode="time"`
+* `theta=-60:1.0:60` - range of incidence angles used when `mode="depth"`.
+* `p=range(-dz/dh,dz/dh,128)` - ray parameter sampling used when `mode="time"`
 * `padz=0.0,padh=0.0` - fractional padding in depth and offset to apply before applying the Fourier transform
-* `taperz=(0,0)` - beginning and end taper in the z-direction (or t-direction) before transforming from `z-h` to `kz-kh`
-* `taperh=(0,0)` - beginning and end taper in the h-direction before transforming from `z-h` to `kz-kh`
-* `taperkz=(0,0)` - beginning and end taper in the kz-direction (or frequency) before transforming from `kz-kh` to `z-h` or `f-kh` to `t-h`
-* `taperkh=(0,0)` - beginning and end taper in the kh-direction before transforming from `kz-kh` to `z-h` or `f-kh` to `t-h`
+* `taperz=(0,0)` - beginning and end taper (fractional) in the z-direction (or t-direction) before transforming from `z-h` to `kz-kh`
+* `taperh=(0,0)` - beginning and end taper (fractional) in the h-direction before transforming from `z-h` to `kz-kh`
+* `taperkz=(0,0)` - beginning and end taper (fractional) in the kz-direction (or frequency) before transforming from `kz-kh` to `z-h` or `f-kh` to `t-h`
+* `taperkh=(0,0)` - beginning and end taper (fractional) in the kh-direction before transforming from `kz-kh` to `z-h` or `f-kh` to `t-h`
 
 # Notes
 
 * It should be possible to extend this operator to 3D
 * If the mode is "time", then `padz` is the padding for the time dimension, `dz` is the time sampling interval, `taperz` is the taper for the time dimension and `tapkerkz` is the taper for frequency.
+* For mode="depth", typically theta needs to cover both positive and negative angles and must be < 90 degrees.
 """
 function JopSlantStack(
         dom::JetAbstractSpace{T};
         theta = collect(-60.0:1.0:60.0),
         p = nothing,
-        dz = -1.0,
-        dh = -1.0,
-        h0 = NaN,
+        dz = 1.0,
+        dh = 1.0,
+        h0 = 0.0,
         padz = 0.0,
         padh = 0.0,
         taperz = (0,0),
@@ -37,7 +38,7 @@ function JopSlantStack(
     mode ∈ ("depth", "time") || error("expected mode to be either 'depth' or 'time', got mode=$(mode)")
     dz < 0.0 && error("expected dz>0.0, got dz=$(dz)")
     dh < 0.0 && error("expected dh>0.0, got dh=$(dh)")
-    isnan(h0) && error("expected finite h0, got h0=$(h0)")
+    mode == "depth" && any(abs.(theta) .>= 90.0) && error("for mode='depth', all theta values must be < 90 degrees in absolute value")
 
     nz,nh = size(dom)
 
@@ -55,8 +56,8 @@ function JopSlantStack(
     nhfft = nextprod([2,3,5,7], round(Int, nh*(1+padh)))
     kh = 2 * fftfreq(nhfft, pi/dh)
 
-    # c*p - used for mode=="depth"
-    cp = @. sin(deg2rad(theta)/2) # factor of 1/2 is to make theta the opening angle -- i.e. go from (theta_s, theta_g)->theta
+    # tan(theta) - used for mode=="depth"
+    tant = @. tan(deg2rad(theta))
 
     # p - used for mode=="time"
     if p === nothing
@@ -64,45 +65,33 @@ function JopSlantStack(
     end
 
     # conversions
-    kz,kh,cp = map(x->convert(Array{T,1}, x), (kz,kh,cp))
+    kz,kh,tant,p = map(x->convert(Array{T,1}, x), (kz,kh,tant,p))
     nzfft,nhfft = map(x->convert(Int64, x), (nzfft,nhfft))
     h0 = T(h0)
 
     # tapers
     TX = JopTaper(dom, (1,2), (taperz[1],taperh[1]), (taperz[2],taperh[2]))
-    TK = JopTaper(JetSpace(Complex{eltype(dom)},div(nzfft,2)+1,mode=="time" ? length(p) : length(cp)), (1,2), (taperkz[1], taperkh[1]), (taperkz[2], taperkh[2]), mode=(:normal,:fftshift))
+    TK = JopTaper(JetSpace(Complex{eltype(dom)},div(nzfft,2)+1,mode=="time" ? length(p) : length(tant)), (1,2), (taperkz[1], taperkh[1]), (taperkz[2], taperkh[2]), mode=(:normal,:fftshift))
 
-    JopLn(dom = dom, rng = JetSpace(T, nz, mode == "time" ? length(p) : length(cp)), df! = JopSlantStack_df!, df′! = JopSlantStack_df′!,
-        s = (;mode, nzfft, nz_pad_rng, nhfft, kz, kh, cp, p, h0, TX, TK))
+    JopLn(dom = dom, rng = JetSpace(T, nz, mode == "time" ? length(p) : length(tant)), df! = JopSlantStack_df!, df′! = JopSlantStack_df′!,
+        s = (;mode, nzfft, nz_pad_rng, nhfft, kz, kh, tant, p, h0, TX, TK))
 end
 export JopSlantStack
 
-function JopSlantStack_df!(d::AbstractArray{T,2}, m::AbstractArray{T,2}; mode, nzfft, nz_pad_rng, nhfft, kz, kh, cp, p, h0, TX, TK, kwargs...) where {T}
-    nh, np, dh = size(m,2), mode == "time" ? length(p) : length(cp), abs(kh[2]-kh[1])
+function JopSlantStack_df!(d::AbstractArray{T,2}, m::AbstractArray{T,2}; mode, nzfft, nz_pad_rng, nhfft, kz, kh, tant, p, h0, TX, TK, kwargs...) where {T}
+    nh, np, dh = size(m,2), mode == "time" ? length(p) : length(tant), abs(kh[2]-kh[1])
 
     mpad = zeros(T, nzfft, nhfft)
     mpad[nz_pad_rng,1:nh] = TX*m
 
     M = rfft(mpad)
 
-    if mode == "depth"
-        # adjoint of conjugate symmetry in kh
-        for ikz = 1:div(nzfft,2)+1
-            for ikh = 2:div(nhfft,2)
-                M[ikz,ikh] += conj(M[ikz,nhfft-ikh+2])
-            end
-            for ikh = div(nhfft,2)+2:nhfft
-                M[ikz,ikh] = 0
-            end
-        end
-    end
-
     compute_kh = mode == "depth" ? slantstack_compute_kh_from_kz : slantstack_compute_kh_from_frequency
-    is_out_of_bounds = mode == "depth" ? (ikh_m1, ikh_p1) -> (ikh_m1 < 1 || ikh_p1 > div(nhfft,2)+1) : (ikh_m1, ikh_p1)->(ikh_m1 < 1 || ikh_p1 > nhfft)
+    is_out_of_bounds = (ikh_m1, ikh_p1)->(ikh_m1 < 1 || ikh_p1 > nhfft)
 
     D = zeros(eltype(M), size(M,1), np)
     for ikz = 1:div(nzfft,2)+1, ip = 1:np
-        ikh_m1, ikh_p1, _kh = compute_kh(ikz, ip, cp, p, kz, kh, nhfft)
+        ikh_m1, ikh_p1, _kh = compute_kh(ikz, ip, tant, p, kz, kh, nhfft)
 
         is_out_of_bounds(ikh_m1, ikh_p1) && continue
 
@@ -111,11 +100,11 @@ function JopSlantStack_df!(d::AbstractArray{T,2}, m::AbstractArray{T,2}; mode, n
             continue
         end
 
-        d_p1 = M[ikz,ikh_p1]*exp(-im*kh[ikh_p1]*h0)
-        a_p1 = abs(kh[ikh_p1] - _kh)/dh
+        a_m1 = (kh[ikh_p1] - _kh)/dh
+        a_p1 = 1 - a_m1
 
+        d_p1 = M[ikz,ikh_p1]*exp(-im*kh[ikh_p1]*h0)
         d_m1 = M[ikz,ikh_m1]*exp(-im*kh[ikh_m1]*h0)
-        a_m1 = abs(_kh - kh[ikh_m1])/dh
 
         D[ikz,ip] = a_m1*d_m1 + a_p1*d_p1
     end
@@ -124,8 +113,8 @@ function JopSlantStack_df!(d::AbstractArray{T,2}, m::AbstractArray{T,2}; mode, n
     d .= _d[nz_pad_rng,1:np] ./ nzfft
 end
 
-function JopSlantStack_df′!(m::AbstractArray{T,2}, d::AbstractArray{T,2}; mode, nzfft, nz_pad_rng, nhfft, kz, kh, cp, p, h0, TX, TK, kwargs...) where {T}
-    nh, np, dh = size(m,2), mode == "time" ? length(p) : length(cp), abs(kh[2]-kh[1])
+function JopSlantStack_df′!(m::AbstractArray{T,2}, d::AbstractArray{T,2}; mode, nzfft, nz_pad_rng, nhfft, kz, kh, tant, p, h0, TX, TK, kwargs...) where {T}
+    nh, np, dh = size(m,2), mode == "time" ? length(p) : length(tant), abs(kh[2]-kh[1])
 
     dpad = zeros(T, nzfft, np)
     dpad[nz_pad_rng,:] = d
@@ -133,11 +122,11 @@ function JopSlantStack_df′!(m::AbstractArray{T,2}, d::AbstractArray{T,2}; mode
     D = TK * (rfft(dpad, 1) ./ nzfft)
 
     compute_kh = mode == "depth" ? slantstack_compute_kh_from_kz : slantstack_compute_kh_from_frequency
-    is_out_of_bounds = mode == "depth" ? (ikh_m1, ikh_p1) -> (ikh_m1 < 1 || ikh_p1 > div(nhfft,2)+1) : (ikh_m1, ikh_p1)->(ikh_m1 < 1 || ikh_p1 > nhfft)
+    is_out_of_bounds = (ikh_m1, ikh_p1)->(ikh_m1 < 1 || ikh_p1 > nhfft)
 
     M = zeros(Complex{T}, div(nzfft,2)+1, nhfft)
     for ikz = 1:div(nzfft,2)+1, ip = 1:np
-        ikh_m1, ikh_p1, _kh = compute_kh(ikz, ip, cp, p, kz, kh, nhfft)
+        ikh_m1, ikh_p1, _kh = compute_kh(ikz, ip, tant, p, kz, kh, nhfft)
 
         is_out_of_bounds(ikh_m1, ikh_p1) && continue
 
@@ -146,38 +135,33 @@ function JopSlantStack_df′!(m::AbstractArray{T,2}, d::AbstractArray{T,2}; mode
             continue
         end
 
+        a_m1 = (kh[ikh_p1] - _kh)/dh
+        a_p1 = 1 - a_m1
+
         m_p1 = D[ikz,ip]*exp(im*kh[ikh_p1]*h0)
-        a_p1 = (kh[ikh_p1] - _kh)/dh
         M[ikz,ikh_p1] += a_p1*m_p1
 
         m_m1 = D[ikz,ip]*exp(im*kh[ikh_m1]*h0)
-        a_m1 = (_kh - kh[ikh_m1])/dh
         M[ikz,ikh_m1] += a_m1*m_m1
-    end
-
-    if mode == "depth"
-        # conjugate symmetry in kh
-        for ikz = 1:div(nzfft,2)+1, ikh = 2:div(nhfft,2)
-            M[ikz,nhfft-ikh+2] = conj(M[ikz,ikh])
-        end
     end
 
     m .= TX * (brfft(M, nzfft)[nz_pad_rng,1:nh])
 end
 
-@inline function slantstack_compute_kh_from_kz(ikz::Int64, ip::Int64, cp, p, kz, kh, nhfft)
-    _kh = 1/(1-cp[ip]^2) - 1
-    _kh < 0 && return -1,-1,1.0
-    _kh = 2*kz[ikz]*sqrt(_kh)
+@inline function slantstack_compute_kh_from_kz(ikz::Int64, ip::Int64, tant, p, kz, kh, nhfft)
+    _kh = -kz[ikz]*tant[ip]
 
     ikh_m1 = floor(Int64, _kh/kh[2]) + 1
     ikh_p1 = ceil(Int64, _kh/kh[2]) + 1
 
+    ikh_m1 = ikh_m1 < 1 ? nhfft + ikh_m1 : ikh_m1
+    ikh_p1 = ikh_p1 < 1 ? nhfft + ikh_p1 : ikh_p1
+
     ikh_m1, ikh_p1, _kh
 end
 
-@inline function slantstack_compute_kh_from_frequency(iω, ip, cp, p, ω, kh, nhfft)
-    _kh = p[ip]*ω[iω] / 2
+@inline function slantstack_compute_kh_from_frequency(iω::Int64, ip::Int64, tant, p, ω, kh, nhfft)
+    _kh = p[ip]*ω[iω]
 
     ikh_m1 = floor(Int64, _kh/kh[2]) + 1
     ikh_p1 = ceil(Int64, _kh/kh[2]) + 1

--- a/test/jop_slantstack.jl
+++ b/test/jop_slantstack.jl
@@ -1,4 +1,4 @@
-using JetPackTransforms, Jets, Test
+using JetPackTransforms, Jets, Test, LinearAlgebra
 
 # depth mode
 @testset "JetSlantStack, dot product test" for T in (Float32, Float64)
@@ -22,7 +22,7 @@ end
     d = A*m
     v,i = findmax(d)
     @test i[1] == 32
-    @test i[2] == findfirst(x->x≈0, state(A).cp)
+    @test i[2] == findfirst(x->x≈0, state(A).tant)
 end
 
 # time mode
@@ -47,4 +47,32 @@ end
     d = A*m
     v,i = findmax(d)
     @test i[1] == 32
+end
+
+# depth-time parity test
+@testset "JetSlantStack, parity" begin
+    theta = collect(-45:0.5:45)
+    # the ray parameters that would give the same results as theta is
+    # p = -tan(θ)
+    p = @. -tan(deg2rad(theta))
+    
+    Ad = JopSlantStack(JetSpace(Float64, 128, 129); mode="depth", theta=theta, p=p, dz=0.01, dh=0.01, h0=-0.64, padz=1, padh=1, taperkz = (0.5,0.5), taperkh = (0.5,0.5))
+    At = JopSlantStack(JetSpace(Float64, 128, 129); mode="time" , theta=theta, p=p, dz=0.01, dh=0.01, h0=-0.64, padz=1, padh=1, taperkz = (0.5,0.5), taperkh = (0.5,0.5))
+    m = zeros(domain(Ad))
+    for i = 1:129
+        m[div(i,4)+20,i] = 1.0
+    end
+    m[16,64] = 1
+    m[64,96] = 1
+    dd = Ad*m
+    dt = At*m
+
+    md = Ad'*dd
+    mt = At'*dt
+
+    err_d = maximum(abs.(dd .- dt)) / maximum(abs.(dd))
+    err_m = maximum(abs.(md .- mt)) / maximum(abs.(md))
+    @show err_d, err_m
+    @test err_d < 1e-7
+    @test err_m < 1e-7
 end


### PR DESCRIPTION
For the slantstack operator
- Fix bug in the Fourier domain bilinear interpolation
- Simplify the mapping function for mode = "depth"
- Update the slantstack doc
- Add unit test for depth-time parity

Below are examples of applying forward and adjoint operators

<img width="1000" height="500" alt="slant_stack_input" src="https://github.com/user-attachments/assets/778d3fd6-6196-40fb-a9ab-d34f7e53912d" />
<img width="1000" height="500" alt="slant_stack" src="https://github.com/user-attachments/assets/c593dfa2-0a5d-409e-9a2e-c07a9fc18adf" />
<img width="1000" height="500" alt="slant_stack_round" src="https://github.com/user-attachments/assets/e4cf4d5c-319d-4beb-8518-3039f077d85e" />
